### PR TITLE
Removed unnecessary return statement

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -18,7 +18,6 @@ const addOrderItems = asyncHandler(async (req, res) => {
   if (orderItems && orderItems.length === 0) {
     res.status(400)
     throw new Error('No order items')
-    return
   } else {
     const order = new Order({
       orderItems,


### PR DESCRIPTION
The "return" is not needed because the "throw Error(...)" will automatically force it to exit the current area of the program.